### PR TITLE
Refactor product gallery layout

### DIFF
--- a/assets/custom-productpage.css
+++ b/assets/custom-productpage.css
@@ -36,25 +36,63 @@
 .product-main + .shopify-section:not(.product-details)::before {
   background-color: transparent !important;
 }
-ab hier neu 
-
-
-
+/* Gallery layout overrides */
 @media (min-width: 769px) {
-  /* Produkt‑Medien‑Spalte auf exakt 600px begrenzen */
+  /* Limit gallery size to keep info above the fold */
   .product-main .product-media {
-    max-width: 600px;
-    flex: 0 0 600px;
+    max-width: 500px;
+    flex: 0 0 500px;
   }
-
-  /* Einzelne Slides des Media-Galerie-Sliders dürfen 600px nicht überschreiten */
+  .product-main .media-gallery__viewer {
+    height: 500px;
+    max-width: 500px;
+  }
   .product-main .media-gallery .media-viewer__item,
   .product-main .media-gallery .media-viewer__item > .media {
-    max-width: 600px;
+    height: 100%;
+    max-width: 500px;
   }
-}
 
-.media-gallery__viewer relative {
-  height: 600px;
-  width: 600px;
+  /* Layout main image with vertical thumbs */
+  .media-gallery__main {
+    display: flex;
+    align-items: center;
+  }
+  .media-gallery__thumbs {
+    margin-top: 0;
+    margin-left: var(--media-gap);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  .media-gallery__thumbs .media-thumbs {
+    flex-direction: column;
+    overflow-y: auto;
+    height: 100%;
+  }
+  .media-gallery__thumbs .media-thumbs__item:not(:last-child) {
+    margin: 0 0 var(--media-gap) 0;
+  }
+
+  /* Thumbnail hover and active border */
+  .media-thumbs__btn {
+    border: 2px solid transparent;
+  }
+  .media-thumbs__btn:hover,
+  .media-thumbs__btn.is-active {
+    border-color: #f68b1f;
+  }
+
+  /* Navigation buttons shown on hover */
+  .media-ctrl__btn {
+    opacity: 0;
+    border-radius: 50%;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    background: #fff;
+    transition: opacity .3s;
+  }
+  .media-gallery__viewer:hover .media-ctrl__btn {
+    opacity: 1;
+  }
 }

--- a/assets/media-gallery.js
+++ b/assets/media-gallery.js
@@ -493,12 +493,21 @@ if (!customElements.get('media-gallery')) {
      * @param {Element} thumb - Thumb item element.
      */
     checkThumbVisibilty(thumb) {
-      const scrollPos = this.thumbs.scrollLeft;
-      const lastVisibleThumbOffset = this.thumbs.clientWidth + scrollPos;
-      const thumbOffset = thumb.offsetLeft;
-
-      if (thumbOffset + thumb.clientWidth > lastVisibleThumbOffset || thumbOffset < scrollPos) {
-        this.thumbs.scrollTo({ left: thumbOffset, behavior: 'smooth' });
+      const isVertical = getComputedStyle(this.thumbs).flexDirection === 'column';
+      if (isVertical) {
+        const scrollPos = this.thumbs.scrollTop;
+        const lastVisibleThumbOffset = this.thumbs.clientHeight + scrollPos;
+        const thumbOffset = thumb.offsetTop;
+        if (thumbOffset + thumb.clientHeight > lastVisibleThumbOffset || thumbOffset < scrollPos) {
+          this.thumbs.scrollTo({ top: thumbOffset, behavior: 'smooth' });
+        }
+      } else {
+        const scrollPos = this.thumbs.scrollLeft;
+        const lastVisibleThumbOffset = this.thumbs.clientWidth + scrollPos;
+        const thumbOffset = thumb.offsetLeft;
+        if (thumbOffset + thumb.clientWidth > lastVisibleThumbOffset || thumbOffset < scrollPos) {
+          this.thumbs.scrollTo({ left: thumbOffset, behavior: 'smooth' });
+        }
       }
     }
 

--- a/snippets/media-gallery.liquid
+++ b/snippets/media-gallery.liquid
@@ -90,9 +90,9 @@
   </a>
 
   <div class="media-gallery__status visually-hidden" role="status"></div>
-
-  <div class="media-gallery__viewer relative">
-    <ul class="media-viewer flex" id="gallery-viewer" role="list" tabindex="0">
+  <div class="media-gallery__main">
+    <div class="media-gallery__viewer relative">
+      <ul class="media-viewer flex" id="gallery-viewer" role="list" tabindex="0">
     {%- for media in product.media -%}
         {%- liquid
           assign lazy_load = true
@@ -210,18 +210,6 @@
     {%- endif -%}
   </div>
 
-  {%- if first_3d_model -%}
-    <button type="button"
-            class="media-xr-button btn btn--secondary btn--icon-with-text font-normal w-full mt-2{% if section.settings.media_layout == 'stacked' %} md:hidden{% endif %}"
-            data-shopify-model3d-id="{{ first_3d_model.id }}"
-            data-shopify-title="{{ product.title | escape }}"
-            data-shopify-xr
-            data-shopify-xr-hidden>
-      {% render 'icon-3d-model' %}
-      {{ 'products.product.xr_button' | t }}
-    </button>
-  {%- endif -%}
-
   {%- if media_count > 1 and section.settings.media_thumbs != 'never' and featured_product == false -%}
     {%- unless section.settings.media_layout == 'stacked' and section.settings.media_thumbs == 'desktop' -%}
       <div class="media-gallery__thumbs{% if section.settings.media_thumbs == 'desktop' %} hidden md:block{% endif %}{% if section.settings.media_layout == 'stacked' %} md:hidden{% endif %} no-js-hidden">
@@ -294,6 +282,19 @@
         </ul>
       </div>
     {%- endunless -%}
+    {%- endif -%}
+  </div>
+
+  {%- if first_3d_model -%}
+    <button type="button"
+            class="media-xr-button btn btn--secondary btn--icon-with-text font-normal w-full mt-2{% if section.settings.media_layout == 'stacked' %} md:hidden{% endif %}"
+            data-shopify-model3d-id="{{ first_3d_model.id }}"
+            data-shopify-title="{{ product.title | escape }}"
+            data-shopify-xr
+            data-shopify-xr-hidden>
+      {% render 'icon-3d-model' %}
+      {{ 'products.product.xr_button' | t }}
+    </button>
   {%- endif -%}
 
   {%- if enable_zoom and lightbox_enabled and featured_product == false -%}


### PR DESCRIPTION
## Summary
- restructure product media gallery to support vertical thumbnail strip
- add hover-revealed navigation buttons with drop shadow
- style thumbnails with orange hover border and limit gallery dimensions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c15b080ccc8326bee5dccfd381ad0f