### PR TITLE
feat: modernize product image gallery

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -103,19 +103,61 @@
   background-color: var(--gallery-bg-color);
 }
 .media-thumbs__btn::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 0;
-  height: 2px;
-  transition: width 0.3s;
-  background-color: rgb(var(--text-color));
+  content: none;
 }
 
-.media-thumbs__btn.is-active::after,
+.media-thumbs__btn:hover,
+.media-thumbs__btn.is-active {
+  border-color: #f68b1f;
+}
+
 .product-media--stacked .media-viewer__item.is-active .media::after {
   width: 100%;
+}
+
+.media-gallery__viewer .media-ctrl__btn {
+  opacity: 0;
+  pointer-events: none;
+  border-radius: 50%;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transition: opacity 0.3s;
+}
+
+.media-gallery__viewer:hover .media-ctrl__btn {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (min-width: 769px) {
+  .media-gallery__wrapper {
+    display: flex;
+    align-items: center;
+  }
+
+  .media-gallery__viewer {
+    flex: 1 1 auto;
+    max-height: 70vh;
+  }
+
+  .media-gallery__thumbs {
+    margin-top: 0;
+    margin-left: var(--media-gap);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .media-gallery__thumbs .media-thumbs {
+    flex-direction: column;
+  }
+
+  .media-thumbs__item {
+    margin-bottom: var(--media-gap);
+  }
+
+  .media-thumbs__item:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .media-thumbs__badge {

--- a/snippets/media-gallery.liquid
+++ b/snippets/media-gallery.liquid
@@ -91,6 +91,7 @@
 
   <div class="media-gallery__status visually-hidden" role="status"></div>
 
+  <div class="media-gallery__wrapper">
   <div class="media-gallery__viewer relative">
     <ul class="media-viewer flex" id="gallery-viewer" role="list" tabindex="0">
     {%- for media in product.media -%}
@@ -210,18 +211,6 @@
     {%- endif -%}
   </div>
 
-  {%- if first_3d_model -%}
-    <button type="button"
-            class="media-xr-button btn btn--secondary btn--icon-with-text font-normal w-full mt-2{% if section.settings.media_layout == 'stacked' %} md:hidden{% endif %}"
-            data-shopify-model3d-id="{{ first_3d_model.id }}"
-            data-shopify-title="{{ product.title | escape }}"
-            data-shopify-xr
-            data-shopify-xr-hidden>
-      {% render 'icon-3d-model' %}
-      {{ 'products.product.xr_button' | t }}
-    </button>
-  {%- endif -%}
-
   {%- if media_count > 1 and section.settings.media_thumbs != 'never' and featured_product == false -%}
     {%- unless section.settings.media_layout == 'stacked' and section.settings.media_thumbs == 'desktop' -%}
       <div class="media-gallery__thumbs{% if section.settings.media_thumbs == 'desktop' %} hidden md:block{% endif %}{% if section.settings.media_layout == 'stacked' %} md:hidden{% endif %} no-js-hidden">
@@ -294,6 +283,19 @@
         </ul>
       </div>
     {%- endunless -%}
+  {%- endif -%}
+  </div>
+
+  {%- if first_3d_model -%}
+    <button type="button"
+            class="media-xr-button btn btn--secondary btn--icon-with-text font-normal w-full mt-2{% if section.settings.media_layout == 'stacked' %} md:hidden{% endif %}"
+            data-shopify-model3d-id="{{ first_3d_model.id }}"
+            data-shopify-title="{{ product.title | escape }}"
+            data-shopify-xr
+            data-shopify-xr-hidden>
+      {% render 'icon-3d-model' %}
+      {{ 'products.product.xr_button' | t }}
+    </button>
   {%- endif -%}
 
   {%- if enable_zoom and lightbox_enabled and featured_product == false -%}


### PR DESCRIPTION
## Summary
- refactor product gallery markup with wrapper and move thumbs beside main image
- add desktop CSS for vertical thumb strip, hover borders, and reveal-on-hover navigation buttons

## Testing
- `npm test` (fails: Could not read package.json)
- `shopify theme check` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c15b080ccc8326bee5dccfd381ad0f