### PR TITLE
Refactor product image gallery layout

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -102,6 +102,10 @@
   border: 1px solid var(--gallery-border-color);
   background-color: var(--gallery-bg-color);
 }
+.media-thumbs__btn:hover,
+.media-thumbs__btn.is-active {
+  border-color: #f68b1f;
+}
 .media-thumbs__btn::after {
   content: "";
   position: absolute;
@@ -149,6 +153,34 @@
   z-index: 1;
 }
 
+@media (min-width: 769px) {
+  .media-gallery__wrapper {
+    display: flex;
+    align-items: center;
+  }
+  .media-gallery__viewer {
+    flex: 1;
+    max-height: 600px;
+    overflow: hidden;
+  }
+  .media-gallery__thumbs {
+    margin-top: 0;
+    margin-left: var(--media-gap);
+    display: flex;
+    flex-direction: column;
+    align-self: center;
+    max-height: 600px;
+    overflow-y: auto;
+  }
+  .media-thumbs {
+    flex-direction: column;
+  }
+  .media-thumbs__item:not(:last-child) {
+    margin-bottom: var(--media-gap);
+    margin-inline-end: 0;
+  }
+}
+
 .media-ctrl__btn,
 .media-ctrl__counter {
   position: absolute;
@@ -161,16 +193,23 @@
 .media-ctrl__btn {
   z-index: 5;
   padding: calc(2 * var(--space-unit));
+  opacity: 0;
+  border-radius: 50%;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  transition: opacity 0.3s;
 }
 .media-ctrl__btn::after {
   width: calc(44px + var(--media-gutter) * 2);
   height: calc(44px + var(--media-gutter) * 2);
 }
+.media-gallery__viewer:hover .media-ctrl__btn {
+  opacity: 1;
+}
 .media-ctrl__btn[name=prev] {
-  left: var(--media-gutter);
+  left: 10px;
 }
 .media-ctrl__btn[name=next] {
-  right: var(--media-gutter);
+  right: 10px;
 }
 .media-ctrl__btn[name=close] {
   top: var(--media-gutter);

--- a/snippets/media-gallery.liquid
+++ b/snippets/media-gallery.liquid
@@ -91,7 +91,8 @@
 
   <div class="media-gallery__status visually-hidden" role="status"></div>
 
-  <div class="media-gallery__viewer relative">
+  <div class="media-gallery__wrapper">
+    <div class="media-gallery__viewer relative">
     <ul class="media-viewer flex" id="gallery-viewer" role="list" tabindex="0">
     {%- for media in product.media -%}
         {%- liquid
@@ -210,18 +211,6 @@
     {%- endif -%}
   </div>
 
-  {%- if first_3d_model -%}
-    <button type="button"
-            class="media-xr-button btn btn--secondary btn--icon-with-text font-normal w-full mt-2{% if section.settings.media_layout == 'stacked' %} md:hidden{% endif %}"
-            data-shopify-model3d-id="{{ first_3d_model.id }}"
-            data-shopify-title="{{ product.title | escape }}"
-            data-shopify-xr
-            data-shopify-xr-hidden>
-      {% render 'icon-3d-model' %}
-      {{ 'products.product.xr_button' | t }}
-    </button>
-  {%- endif -%}
-
   {%- if media_count > 1 and section.settings.media_thumbs != 'never' and featured_product == false -%}
     {%- unless section.settings.media_layout == 'stacked' and section.settings.media_thumbs == 'desktop' -%}
       <div class="media-gallery__thumbs{% if section.settings.media_thumbs == 'desktop' %} hidden md:block{% endif %}{% if section.settings.media_layout == 'stacked' %} md:hidden{% endif %} no-js-hidden">
@@ -294,6 +283,19 @@
         </ul>
       </div>
     {%- endunless -%}
+  {%- endif -%}
+  </div>
+
+  {%- if first_3d_model -%}
+    <button type="button"
+            class="media-xr-button btn btn--secondary btn--icon-with-text font-normal w-full mt-2{% if section.settings.media_layout == 'stacked' %} md:hidden{% endif %}"
+            data-shopify-model3d-id="{{ first_3d_model.id }}"
+            data-shopify-title="{{ product.title | escape }}"
+            data-shopify-xr
+            data-shopify-xr-hidden>
+      {% render 'icon-3d-model' %}
+      {{ 'products.product.xr_button' | t }}
+    </button>
   {%- endif -%}
 
   {%- if enable_zoom and lightbox_enabled and featured_product == false -%}


### PR DESCRIPTION
## Summary
- Rework product media gallery to position main image left with vertical thumbnail strip
- Style thumbnails with orange hover/active border and add hover-revealed navigation buttons
- Constrain gallery height for improved above-the-fold visibility and responsive stacking

## Testing
- `npx @shopify/cli@latest theme check` (fails: 18 errors, 25 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c15b080ccc8326bee5dccfd381ad0f