### PR TITLE
Refactor product gallery layout and controls

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -30,6 +30,78 @@
   --media-gap: calc(2 * var(--space-unit));
   --media-gutter: calc(4 * var(--space-unit));
 }
+
+.pg {
+  --pg-media-max: clamp(420px, 52vw, 720px);
+}
+.pg__media {
+  max-width: var(--pg-media-max);
+  margin-inline: auto;
+  position: relative;
+}
+.pg__media .media-viewer__item,
+.pg__media img,
+.pg__media video,
+.pg__media model-viewer {
+  width: 100%;
+  height: auto;
+  max-height: min(72vh, 820px);
+  object-fit: contain;
+}
+.pg__thumbs {
+  max-width: var(--pg-media-max);
+  margin: 12px auto 0;
+}
+.pg__thumbs .media-thumbs {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(56px, 72px);
+  gap: 12px;
+  justify-content: center;
+  align-items: center;
+  overflow-x: visible;
+  scroll-snap-type: none;
+}
+.pg__thumbs .media-thumbs__item {
+  flex: 0 0 auto;
+}
+.pg__thumbs .media-thumbs__btn {
+  aspect-ratio: 1/1;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: #fff;
+}
+.pg__thumbs .media-thumbs__btn > img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.pg__thumbs .media-thumbs__btn[aria-selected="true"] {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+.pg__thumbs .media-thumbs__btn:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+.pg__thumbs .media-thumbs__btn:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+@media (max-width: 749px) {
+  .pg__thumbs .media-thumbs {
+    display: flex;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    padding-inline: 12px;
+    gap: 12px;
+  }
+  .pg__thumbs .media-thumbs__item {
+    flex: 0 0 64px;
+    scroll-snap-align: center;
+  }
+}
 .media-gallery .skip-link.btn {
   left: 16px;
 }

--- a/assets/media-gallery.js
+++ b/assets/media-gallery.js
@@ -119,9 +119,7 @@ if (!customElements.get('media-gallery')) {
       const handleControlClick = (evt) => {
         if (evt.detail) evt.currentTarget.blur();
         requestAnimationFrame(() => {
-          setTimeout(() => {
-            if (!this.isHovering) hide();
-          }, 0);
+          if (!this.isHovering) hide();
         });
       };
       [this.prevBtn, this.nextBtn].forEach((btn) => {
@@ -525,11 +523,11 @@ if (!customElements.get('media-gallery')) {
 
       this.thumbs.querySelectorAll('.media-thumbs__btn').forEach((el) => {
         el.classList.remove('is-active');
-        el.removeAttribute('aria-current');
+        el.setAttribute('aria-selected', 'false');
       });
 
       btn.classList.add('is-active');
-      btn.setAttribute('aria-current', 'true');
+      btn.setAttribute('aria-selected', 'true');
       this.checkThumbVisibilty(this.currentThumb);
     }
 
@@ -549,13 +547,12 @@ if (!customElements.get('media-gallery')) {
      * @param {Element} thumb - Thumb item element.
      */
     checkThumbVisibilty(thumb) {
-      const scrollPos = this.thumbs.scrollLeft;
-      const lastVisibleThumbOffset = this.thumbs.clientWidth + scrollPos;
-      const thumbOffset = thumb.offsetLeft;
-
-      if (thumbOffset + thumb.clientWidth > lastVisibleThumbOffset || thumbOffset < scrollPos) {
-        this.thumbs.scrollTo({ left: thumbOffset, behavior: 'smooth' });
-      }
+      if (!thumb) return;
+      const thumbRect = thumb.getBoundingClientRect();
+      const thumbsRect = this.thumbs.getBoundingClientRect();
+      const offset =
+        thumbRect.left + thumbRect.width / 2 - (thumbsRect.left + thumbsRect.width / 2);
+      this.thumbs.scrollTo({ left: this.thumbs.scrollLeft + offset, behavior: 'smooth' });
     }
 
     /**

--- a/snippets/media-gallery.liquid
+++ b/snippets/media-gallery.liquid
@@ -59,8 +59,9 @@
 -%}
 
 <media-gallery
-    class="media-gallery relative"
+    class="media-gallery relative pg"
     role="region"
+    data-gallery
     {% if featured_product %}
       data-is-featured="true"
     {% endif %}
@@ -91,7 +92,7 @@
 
   <div class="media-gallery__status visually-hidden" role="status"></div>
 
-  <div class="media-gallery__viewer relative hover-nav">
+  <div class="media-gallery__viewer pg__media relative hover-nav">
     <ul class="media-viewer flex" id="gallery-viewer" role="list" tabindex="0">
     {%- for media in product.media -%}
         {%- liquid
@@ -111,7 +112,7 @@
             assign lazy_load = false
           endif
         -%}
-        <li class="media-viewer__item{% if media.id == featured_media.id or select_first_image %} is-current-variant{% endif %}{% if section.settings.hide_variants and variant_images contains media.src %} media-viewer__item--variant{% endif %}{% if section.settings.media_layout == 'stacked' and media.id == featured_media.id %}{% if underline_active and section.settings.enable_media_grouping == false %} is-active{% endif %}{% endif %}{% if media_count == 1 %} media-viewer__item--single{% endif %}" data-media-id="{{ media.id }}" data-media-type="{{ media.media_type }}">
+        <li id="Slide-{{ media.id }}" class="media-viewer__item{% if media.id == featured_media.id or select_first_image %} is-current-variant{% endif %}{% if section.settings.hide_variants and variant_images contains media.src %} media-viewer__item--variant{% endif %}{% if section.settings.media_layout == 'stacked' and media.id == featured_media.id %}{% if underline_active and section.settings.enable_media_grouping == false %} is-active{% endif %}{% endif %}{% if media_count == 1 %} media-viewer__item--single{% endif %}" data-media-id="{{ media.id }}" data-media-type="{{ media.media_type }}">
           {%- if enable_zoom and lightbox_enabled and media.media_type == 'image' -%}
             <gallery-zoom-open class="gallery-zoom-open cursor-pointer w-full">
           {%- endif -%}
@@ -136,8 +137,7 @@
       {%- if section.settings.media_arrows != 'never' or section.settings.show_slide_count -%}
         <div class="media-ctrl{% unless section.settings.media_thumbs == 'always' %} media-ctrl--lg-down-static{% endunless %}{% if section.settings.media_layout == 'stacked' %} md:hidden{% endif %} no-js-hidden">
           {% if section.settings.media_arrows != 'never' %}
-            <button type="button" class="media-ctrl__btn tap-target vertical-center btn{% if section.settings.media_arrows == 'desktop' %} visible-lg{% elsif section.settings.media_arrows == 'mobile' %} lg:hidden{% endif %}" name="prev" aria-controls="gallery-viewer" disabled hidden>
-              <span class="visually-hidden">{{ 'products.product.media.previous' | t }}</span>
+            <button type="button" class="media-ctrl__btn tap-target vertical-center btn{% if section.settings.media_arrows == 'desktop' %} visible-lg{% elsif section.settings.media_arrows == 'mobile' %} lg:hidden{% endif %}" name="prev" aria-controls="gallery-viewer" aria-label="{{ 'products.product.media.previous' | t }}" disabled hidden>
               {% render 'icon-chevron-left' %}
             </button>
           {% endif %}
@@ -150,8 +150,7 @@
             </div>
           {% endif %}
           {% if section.settings.media_arrows != 'never' %}
-            <button type="button" class="media-ctrl__btn tap-target vertical-center btn{% if section.settings.media_arrows == 'desktop' %} visible-lg{% elsif section.settings.media_arrows == 'mobile' %} lg:hidden{% endif %}" name="next" aria-controls="gallery-viewer">
-              <span class="visually-hidden">{{ 'products.product.media.next' | t }}</span>
+            <button type="button" class="media-ctrl__btn tap-target vertical-center btn{% if section.settings.media_arrows == 'desktop' %} visible-lg{% elsif section.settings.media_arrows == 'mobile' %} lg:hidden{% endif %}" name="next" aria-controls="gallery-viewer" aria-label="{{ 'products.product.media.next' | t }}">
               {% render 'icon-chevron-right' %}
             </button>
           {% endif %}
@@ -224,8 +223,8 @@
 
   {%- if media_count > 1 and section.settings.media_thumbs != 'never' and featured_product == false -%}
     {%- unless section.settings.media_layout == 'stacked' and section.settings.media_thumbs == 'desktop' -%}
-      <div class="media-gallery__thumbs{% if section.settings.media_thumbs == 'desktop' %} hidden md:block{% endif %}{% if section.settings.media_layout == 'stacked' %} md:hidden{% endif %} no-js-hidden">
-        <ul class="media-thumbs relative flex" role="list">
+      <div class="media-gallery__thumbs pg__thumbs{% if section.settings.media_thumbs == 'desktop' %} hidden md:block{% endif %}{% if section.settings.media_layout == 'stacked' %} md:hidden{% endif %} no-js-hidden">
+        <ul class="media-thumbs relative flex" role="tablist" aria-label="{{ 'products.product.media' | t }}">
           {%- for media in product.media -%}
             {%- liquid
               capture thumb_index
@@ -244,7 +243,7 @@
               endif
             -%}
             <li class="media-thumbs__item{% if section.settings.hide_variants and variant_images contains media.src %} media-thumbs__item--variant{% endif %}" data-media-id="{{ media.id }}">
-              <button class="media-thumbs__btn media relative w-full{% if settings.blend_product_images %} image-blend{% endif %}{% if active and section.settings.enable_media_grouping == false %} is-active{% endif %}"{% if active %} aria-current="true"{% endif %} aria-controls="gallery-viewer"{% if section.settings.thumb_ratio != 'natural' %} style="padding-top: {{ 1 | divided_by: thumb_ratio | times: 100 }}%;"{% endif %}>
+              <button class="media-thumbs__btn media relative w-full{% if settings.blend_product_images %} image-blend{% endif %}{% if active and section.settings.enable_media_grouping == false %} is-active{% endif %}" role="tab" aria-controls="Slide-{{ media.id }}" aria-selected="{{ active }}"{% if section.settings.thumb_ratio != 'natural' %} style="padding-top: {{ 1 | divided_by: thumb_ratio | times: 100 }}%;"{% endif %}>
                 <span class="visually-hidden">
                   {%- if media.media_type == 'image' -%}
                     {{- 'products.product.media.load_image' | t: index: image_index -}}


### PR DESCRIPTION
## Summary
- Refactor product gallery markup for `.pg` wrapper with ARIA-friendly thumbnails
- Constrain media sizing and center thumbnail row beneath active image
- Improve slider JS to center active thumb and hide navigation arrows after click

## Testing
- `theme-check` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c166a384dc8326af74048fe8447e8e