### PR TITLE
Fix PDP media viewer overflow and spacing

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -38,15 +38,25 @@
   max-width: var(--pg-media-max);
   margin-inline: auto;
   position: relative;
+  height: auto;
+  overflow-y: visible;
+  overscroll-behavior: auto;
 }
+
+.pg__media .media-viewer {
+  overflow-y: hidden;
+}
+
 .pg__media .media-viewer__item,
+.pg__media .media,
 .pg__media img,
 .pg__media video,
 .pg__media model-viewer {
   width: 100%;
-  height: auto;
+  height: auto !important;
   max-height: min(72vh, 820px);
   object-fit: contain;
+  overflow-y: visible !important;
 }
 .pg__thumbs {
   max-width: var(--pg-media-max);

--- a/assets/media-gallery.js
+++ b/assets/media-gallery.js
@@ -43,6 +43,19 @@ if (!customElements.get('media-gallery')) {
       this.loadingSpinner = this.querySelector('.loading-spinner');
       this.xrButton = this.querySelector('.media-xr-button');
 
+      this.mediaWrapper = this.querySelector('.pg__media');
+      if (this.mediaWrapper) {
+        this.mediaWrapper.addEventListener(
+          'wheel',
+          (e) => {
+            const el = e.currentTarget;
+            const needsScroll = el.scrollHeight > Math.ceil(el.clientHeight + 1);
+            if (!needsScroll) e.preventDefault();
+          },
+          { passive: false }
+        );
+      }
+
       if (this.hasAttribute('data-zoom-enabled')) {
         this.galleryModal = this.querySelector('.js-media-zoom-template').content.firstElementChild.cloneNode(true);
       }


### PR DESCRIPTION
## Summary
- prevent inner scrolling in PDP media viewer and ensure page scrolls instead
- add wheel handler to avoid accidental gallery scroll when content fits

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c16949f0c08326845997df956acb7f