### PR TITLE
fix: remove internal product image scroll

### DIFF
--- a/assets/custom-productpage.css
+++ b/assets/custom-productpage.css
@@ -36,9 +36,6 @@
 .product-main + .shopify-section:not(.product-details)::before {
   background-color: transparent !important;
 }
-ab hier neu 
-
-
 
 @media (min-width: 769px) {
   /* Produkt‑Medien‑Spalte auf exakt 600px begrenzen */
@@ -54,7 +51,19 @@ ab hier neu
   }
 }
 
-.media-gallery__viewer relative {
-  height: 600px;
-  width: 600px;
+/* Prevent internal scrolling of the main product image area */
+#product-media .media-viewer {
+  overflow-x: hidden;
+}
+
+/* Maintain a consistent gap between main image and thumbnails */
+#product-media .media-gallery__thumbs {
+  margin-top: 16px;
+}
+
+/* Ensure product images keep their aspect ratio */
+#product-media .media-viewer__item img {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
 }


### PR DESCRIPTION
## Summary
- prevent scrolling inside main product image area
- maintain spacing and proportions for product media

## Testing
- `theme-check`

------
https://chatgpt.com/codex/tasks/task_e_68c16ebae08483269bfb7fbfff32c922