### PR TITLE
style: card layout for product gallery

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -128,6 +128,13 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }
 
+.product-media-card {
+  padding: 32px;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
 .product-info-card > .product-info__block {
   margin: 0 0 22px;
 }

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -101,25 +101,27 @@
 <div class="container">
   <div class="product js-product" data-section="{{ section.id }}">
     <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
-      {%- if product.media.size > 0 -%}
-        {% render 'media-gallery',
-          product: product,
-          featured_media: featured_media,
-          media_ratio: media_ratio,
-          media_crop: section.settings.media_crop,
-          thumb_ratio: thumb_ratio,
-          thumb_crop: section.settings.thumb_crop,
-          first_3d_model: first_3d_model,
-          enable_zoom: section.settings.enable_zoom,
-          enable_lightbox_mobile: section.settings.enable_lightbox_mobile,
-          zoom_mode: section.settings.zoom_mode,
-          zoom_level: section.settings.hover_zoom
-        %}
-      {%- else -%}
-        <div class="media relative">
-          {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
-        </div>
-      {%- endif -%}
+      <div class="product-media-card">
+        {%- if product.media.size > 0 -%}
+          {% render 'media-gallery',
+            product: product,
+            featured_media: featured_media,
+            media_ratio: media_ratio,
+            media_crop: section.settings.media_crop,
+            thumb_ratio: thumb_ratio,
+            thumb_crop: section.settings.thumb_crop,
+            first_3d_model: first_3d_model,
+            enable_zoom: section.settings.enable_zoom,
+            enable_lightbox_mobile: section.settings.enable_lightbox_mobile,
+            zoom_mode: section.settings.zoom_mode,
+            zoom_level: section.settings.hover_zoom
+          %}
+        {%- else -%}
+          <div class="media relative">
+            {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
+          </div>
+        {%- endif -%}
+      </div>
     </div>
 
     <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"


### PR DESCRIPTION
## Summary
- wrap main product gallery in `.product-media-card` container for consistent card styling
- add `.product-media-card` CSS mirroring `.product-info-card`'s background, radius, padding, and shadow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1748d2d1c8326a3f8b39b926a59fc