### PR TITLE
Align product gallery with sticky product info

### DIFF
--- a/assets/pdp-sticky.js
+++ b/assets/pdp-sticky.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const gallery = document.getElementById('galleryCard');
+  const info = document.getElementById('infoCard');
+  if (!gallery || !info) return;
+
+  const mediaQuery = window.matchMedia('(min-width: 990px)');
+
+  function equalize() {
+    gallery.style.height = '';
+    info.style.height = '';
+    if (mediaQuery.matches) {
+      const height = Math.max(gallery.offsetHeight, info.offsetHeight);
+      gallery.style.height = height + 'px';
+      info.style.height = height + 'px';
+    }
+  }
+
+  equalize();
+  window.addEventListener('resize', equalize);
+});

--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -142,3 +142,14 @@
 .product-info-card > .product-info__block:last-child {
   margin-bottom: 0;
 }
+
+@media (min-width: 990px) {
+  #galleryCard {
+    position: sticky;
+    top: var(--header-end-padded, 70px);
+  }
+
+  .product-info__sticky {
+    top: var(--header-end-padded, 70px);
+  }
+}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -34,6 +34,7 @@
 {%- endif -%}
 
 <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'pdp-sticky.js' | asset_url }}" defer="defer"></script>
 
 {%- liquid
   # constants
@@ -99,9 +100,9 @@
 {%- endif -%}
 
 <div class="container">
-  <div class="product js-product" data-section="{{ section.id }}">
+  <div id="pdp-grid" class="product js-product pdp-grid" data-section="{{ section.id }}">
     <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
-      <div class="product-media-card">
+      <div class="product-media-card" id="galleryCard">
         {%- if product.media.size > 0 -%}
           {% render 'media-gallery',
             product: product,
@@ -137,7 +138,7 @@
         <a class="product-options--anchor" id="product-info" rel="nofollow"></a>
       {%- endif -%}
 
-      <div class="product-info-card">
+      <div class="product-info-card" id="infoCard">
       {%- for block in section.blocks -%}
         {%- case block.type -%}
           {%- when '@app' -%}


### PR DESCRIPTION
## Summary
- Ensure product gallery and info cards share unified wrapper and IDs for height syncing
- Add sticky positioning to gallery and info cards on desktop
- Introduce script to equalize card heights above 990px viewport width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c17b780c4083269feb267ff3be2ca7