### PR TITLE
Align product gallery with sticky info card

### DIFF
--- a/assets/custom-productpage.css
+++ b/assets/custom-productpage.css
@@ -36,7 +36,7 @@
 .product-main + .shopify-section:not(.product-details)::before {
   background-color: transparent !important;
 }
-ab hier neu 
+/* ab hier neu */
 
 
 
@@ -57,4 +57,48 @@ ab hier neu
 .media-gallery__viewer relative {
   height: 600px;
   width: 600px;
+}
+
+@media (max-width: 989px) {
+  .product-main .product-media,
+  .product-main .product-info {
+    width: 100%;
+    float: none;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
+  }
+  .product-info__sticky,
+  .product-main .product-media {
+    position: static;
+    top: auto;
+  }
+  #pdp-grid {
+    display: block;
+  }
+  #galleryCard {
+    height: auto;
+  }
+}
+
+@media (min-width: 990px) {
+  #pdp-grid {
+    display: flex;
+    align-items: flex-start;
+  }
+  #pdp-grid #product-media,
+  #pdp-grid .product-info {
+    float: none;
+  }
+  #galleryCard,
+  #infoCard {
+    height: 100%;
+  }
+  .product-main .product-media {
+    position: sticky;
+    top: var(--header-end-padded, 70px);
+  }
+  .product-info__sticky {
+    position: sticky;
+    top: var(--header-end-padded, 48px);
+  }
 }

--- a/assets/custom.js
+++ b/assets/custom.js
@@ -404,3 +404,20 @@
  *
  * Have fun! - The Clean Canvas Development Team.
  */
+
+document.addEventListener('DOMContentLoaded', () => {
+  const gallery = document.getElementById('galleryCard');
+  const info = document.getElementById('infoCard');
+  if (!gallery || !info) return;
+
+  const syncHeights = () => {
+    if (window.innerWidth >= 990) {
+      gallery.style.height = info.offsetHeight + 'px';
+    } else {
+      gallery.style.height = '';
+    }
+  };
+
+  syncHeights();
+  window.addEventListener('resize', syncHeights);
+});

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -100,8 +100,9 @@
 
 <div class="container">
   <div class="product js-product" data-section="{{ section.id }}">
-    <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
-      <div class="product-media-card">
+    <div class="pdp-grid" id="pdp-grid">
+      <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
+        <div class="product-media-card" id="galleryCard">
         {%- if product.media.size > 0 -%}
           {% render 'media-gallery',
             product: product,
@@ -121,11 +122,11 @@
             {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
           </div>
         {%- endif -%}
+        </div>
       </div>
-    </div>
 
-    <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
-         {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media"{% endif %}>
+      <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
+           {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media"{% endif %}>
       {%- if section.settings.stick_on_scroll -%}
       <script src="{{ 'sticky-scroll-direction.js' | asset_url }}" defer="defer"></script>
       <sticky-scroll-direction data-min-sticky-size="md">
@@ -137,7 +138,7 @@
         <a class="product-options--anchor" id="product-info" rel="nofollow"></a>
       {%- endif -%}
 
-      <div class="product-info-card">
+      <div class="product-info-card" id="infoCard">
       {%- for block in section.blocks -%}
         {%- case block.type -%}
           {%- when '@app' -%}
@@ -695,6 +696,7 @@
         </div>
       </sticky-scroll-direction>
       {%- endif -%}
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Wrap gallery and info sections in a unified `pdp-grid` and add card IDs for height syncing
- Add responsive CSS to equalize card heights and enable sticky layout on desktop while stacking on mobile
- Include lightweight JS to mirror the info card height to the gallery card

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c17b780c4083269feb267ff3be2ca7