### PR TITLE
Align product gallery and info card heights with sticky layout

### DIFF
--- a/assets/product-cards.js
+++ b/assets/product-cards.js
@@ -1,0 +1,17 @@
+(function() {
+  const mq = window.matchMedia('(min-width: 990px)');
+  const gallery = document.getElementById('galleryCard');
+  const info = document.getElementById('infoCard');
+  if (!gallery || !info) return;
+
+  function syncHeights() {
+    if (mq.matches) {
+      gallery.style.height = info.offsetHeight + 'px';
+    } else {
+      gallery.style.height = '';
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', syncHeights);
+  window.addEventListener('resize', syncHeights);
+})();

--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -107,7 +107,7 @@
   }
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 990px) {
   .product-main .product-media {
     position: sticky;
     top: var(--header-end-padded, 70px);
@@ -141,4 +141,23 @@
 
 .product-info-card > .product-info__block:last-child {
   margin-bottom: 0;
+}
+
+@media (max-width: 989px) {
+  .product-info__sticky {
+    position: static;
+    top: auto;
+  }
+}
+
+@media (min-width: 990px) {
+  .product-info__sticky {
+    top: var(--header-end-padded, 70px);
+  }
+
+  #galleryCard,
+  #infoCard {
+    position: sticky;
+    top: var(--header-end-padded, 70px);
+  }
 }

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -34,6 +34,7 @@
 {%- endif -%}
 
 <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'product-cards.js' | asset_url }}" defer="defer"></script>
 
 {%- liquid
   # constants
@@ -99,9 +100,9 @@
 {%- endif -%}
 
 <div class="container">
-  <div class="product js-product" data-section="{{ section.id }}">
+  <div id="pdp-grid" class="product js-product pdp-grid" data-section="{{ section.id }}">
     <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
-      <div class="product-media-card">
+      <div class="product-media-card" id="galleryCard">
         {%- if product.media.size > 0 -%}
           {% render 'media-gallery',
             product: product,
@@ -137,7 +138,7 @@
         <a class="product-options--anchor" id="product-info" rel="nofollow"></a>
       {%- endif -%}
 
-      <div class="product-info-card">
+      <div class="product-info-card" id="infoCard">
       {%- for block in section.blocks -%}
         {%- case block.type -%}
           {%- when '@app' -%}


### PR DESCRIPTION
## Summary
- ensure gallery and info cards share a common grid and unique IDs
- add sticky positioning and mobile opt-out in product page CSS
- sync gallery height to info card with lightweight JS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c17b780c4083269feb267ff3be2ca7